### PR TITLE
Incompatible version of openvidu-browser

### DIFF
--- a/src/main/angular/package.json
+++ b/src/main/angular/package.json
@@ -44,7 +44,7 @@
     "time-ago-pipe": "~1.1.1",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.6.23",
-    "openvidu-browser": "1.7.0"
+    "openvidu-browser": "1.9.0"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.41",


### PR DESCRIPTION
There is no LocalRecorder in openvidu-browser version 1.7.0, so the version required should be 1.9.0